### PR TITLE
Changes to ensure modularity of fringez.

### DIFF
--- a/bin/fringez-clean
+++ b/bin/fringez-clean
@@ -10,9 +10,9 @@ import glob
 import subprocess
 import sys
 from fringez.fringe import remove_fringe
-from fringez.utils import return_model_template, 
+from fringez.utils import (return_model_template, 
                           return_image_cid_qid, 
-                          return_fringe_model_name
+                          return_fringe_model_name)
 
 def main():
     """Subtracts a saved fringe model from the provided science image."""

--- a/bin/fringez-clean
+++ b/bin/fringez-clean
@@ -10,31 +10,9 @@ import glob
 import subprocess
 import sys
 from fringez.fringe import remove_fringe
-
-
-def return_model_template(fringe_model_folder):
-    model = glob.glob(fringe_model_folder + '/fringe*model')[0]
-    model_prefix = model.split('.')[0]
-    model_suffix = '.'.join(model.split('.')[-2:])
-    return model_prefix, model_suffix
-
-
-def return_image_cid_qid(image):
-    cid = image.split('_')[4]
-    qid = image.split('_')[6]
-    return cid, qid
-
-
-def return_fringe_model_name(image, fringe_model_folder):
-    model_prefix, model_suffix = return_model_template(fringe_model_folder)
-    cid, qid = return_image_cid_qid(image)
-
-    fringe_model = model_prefix
-    fringe_model += '.%s_%s.' % (cid, qid)
-    fringe_model += model_suffix
-
-    return fringe_model
-
+from fringez.utils import return_model_template, 
+                          return_image_cid_qid, 
+                          return_fringe_model_name
 
 def main():
     """Subtracts a saved fringe model from the provided science image."""

--- a/bin/fringez-clean
+++ b/bin/fringez-clean
@@ -9,7 +9,7 @@ import argparse
 import glob
 import subprocess
 import sys
-from fringez.fringe import remove_fringe
+from fringez.fringe import remove_fringe_and_save
 from fringez.utils import (return_model_template, 
                           return_image_cid_qid, 
                           return_fringe_model_name)
@@ -107,7 +107,7 @@ def main():
                 image_name = image_names[idx]
                 fringe_model_name = return_fringe_model_name(
                     image_name, args.fringe_model_folder)
-                remove_fringe(image_name=image_name,
+                remove_fringe_and_save(image_name=image_name,
                               fringe_model_name=fringe_model_name,
                               debugFlag=args.debugFlag)
                 idx += size
@@ -115,13 +115,13 @@ def main():
             for image_name in image_names:
                 fringe_model_name = return_fringe_model_name(
                     image_name, args.fringe_model_folder)
-                remove_fringe(image_name=image_name,
+                remove_fringe_and_save(image_name=image_name,
                               fringe_model_name=fringe_model_name,
                               debugFlag=args.debugFlag)
     else:
         # Subtract the fringe model from the --image-name science image
         print('*** --single-image selected, cleaning a single image')
-        remove_fringe(image_name=args.image_name,
+        remove_fringe_and_save(image_name=args.image_name,
                       fringe_model_name=args.fringe_model_name,
                       debugFlag=args.debugFlag)
 

--- a/bin/fringez-download
+++ b/bin/fringez-download
@@ -11,34 +11,7 @@ import argparse
 import requests
 import wget
 from bs4 import BeautifulSoup
-
-NERSC_url = 'https://portal.nersc.gov/project/ptf/' \
-            'iband/ztf_iband_fringe_models_'
-
-
-def download_models(model_date, fringe_model_dir, model_id=None):
-    source_code = requests.get(NERSC_url + model_date)
-    plain_text = source_code.text
-    soup = BeautifulSoup(plain_text, "html.parser")
-
-    outdir = fringe_model_dir + '/' + model_date
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
-
-    if model_id:
-        print('Downloading model and model lists %s to %s' % (model_id,
-                                                              outdir))
-    else:
-        print('Downloading all models and model lists to %s' % outdir)
-
-    for link in soup.findAll('a'):
-        href = link.get('href')
-        if 'model' not in href:
-            continue
-        if model_id and model_id not in href:
-            continue
-        wget.download(NERSC_url + model_date + '/' + href, out=outdir)
-
+from fringe.utils import download_models
 
 def main():
     """Download pre-generated fringe models from the NERSC web portal."""

--- a/bin/fringez-download
+++ b/bin/fringez-download
@@ -8,9 +8,6 @@ Download pre-generated fringe models from the NERSC web portal.
 import os
 import sys
 import argparse
-import requests
-import wget
-from bs4 import BeautifulSoup
 from fringe.utils import download_models
 
 def main():

--- a/fringez/fringe.py
+++ b/fringez/fringe.py
@@ -5,8 +5,7 @@ import numpy as np
 import sys
 import os
 import glob
-from fringez.utils import create_fits
-from fringez.utils import flatten_images
+from fringez.utils import create_fits, flatten_images
 
 
 def generate_fringe_map(image, mask_image=None):
@@ -229,7 +228,7 @@ def remove_fringe(image, fringe_model_name, mask=None):
     """
     Mid-Level function of fringe removal.
     """
-    
+
     fringe_map, median_absdev = generate_fringe_map(image, mask_image=mask)
 
     fringe_model = np.load(fringe_model_name)

--- a/fringez/fringe.py
+++ b/fringez/fringe.py
@@ -183,9 +183,10 @@ def calculate_fringe_bias(fringe_map, median_absdev, fringe_model):
     return fringe_bias, fringe_proj
 
 
-def remove_fringe(image_name,
+def remove_fringe_and_save(image_name,
                   fringe_model_name,
-                  debugFlag=False):
+                  debugFlag=False,
+                  mask=None):
     """ Subtracts the fringe bias image from the science image, resulting in
     a clean image with extension *sciimg.clean.fits.
 
@@ -206,17 +207,12 @@ def remove_fringe(image_name,
         image = f[0].data
         header = f[0].header
 
-    fringe_map, median_absdev = generate_fringe_map(image)
-
-    fringe_model = np.load(fringe_model_name)
-
-    fringe_bias, fringe_proj = calculate_fringe_bias(fringe_map, median_absdev, fringe_model)
-    fringe_bias = fringe_bias.reshape(image.shape)
+    image_clean, fringe_bias, fringe_proj = remove_fringe(image, fringe_model_name, 
+                                                          mask=mask)
 
     header = append_eigenvalues_to_header(header, fringe_proj)
     header['FRNGMDL'] = os.path.basename(fringe_model_name)
 
-    image_clean = image - fringe_bias
     image_clean_fname = image_name.replace('.fits', '.clean.fits')
     create_fits(image_clean_fname, image_clean, header)
     print('-- %s saved to disk' % image_clean_fname)
@@ -228,3 +224,19 @@ def remove_fringe(image_name,
         create_fits(fname, fringe_bias, header)
 
         print('-- %s saved to disk' % fname)
+
+def remove_fringe(image, fringe_model_name, mask=None):
+    """
+    Mid-Level function of fringe removal.
+    """
+    
+    fringe_map, median_absdev = generate_fringe_map(image, mask_image=mask)
+
+    fringe_model = np.load(fringe_model_name)
+
+    fringe_bias, fringe_proj = calculate_fringe_bias(fringe_map, median_absdev, fringe_model)
+    fringe_bias = fringe_bias.reshape(image.shape)
+
+    image_clean = image - fringe_bias
+
+    return image_clean, fringe_bias, fringe_proj

--- a/fringez/metric.py
+++ b/fringez/metric.py
@@ -4,8 +4,8 @@ metric.py
 """
 
 from astropy.io import fits
-from photutils import MedianBackground, StdBackgroundRMS
-from photutils import aperture_photometry, CircularAperture
+from photutils import (MedianBackground, StdBackgroundRMS,
+                        aperture_photometry, CircularAperture)
 from photutils.background import Background2D
 import numpy as np
 import os

--- a/fringez/utils.py
+++ b/fringez/utils.py
@@ -5,7 +5,9 @@ import glob
 import os
 import shutil
 from astropy.io import fits
-import shutil
+import requests
+import wget
+from bs4 import BeautifulSoup
 
 
 NERSC_url = 'https://portal.nersc.gov/project/ptf/' \

--- a/fringez/utils.py
+++ b/fringez/utils.py
@@ -8,6 +8,10 @@ from astropy.io import fits
 import shutil
 
 
+NERSC_url = 'https://portal.nersc.gov/project/ptf/' \
+            'iband/ztf_iband_fringe_models_'
+
+
 def flatten_images(images):
     """Flattens images for use in 1D analysis"""
 
@@ -109,3 +113,49 @@ def generate_random_ds9_list(n_random=6):
         for idx in idx_arr:
             f.write('%s\n' % fname_arr[idx])
             f.write('%s\n' % fname_arr[idx].replace('.clean', ''))
+
+def return_model_template(fringe_model_folder):
+    model = glob.glob(fringe_model_folder + '/fringe*model')[0]
+    model_prefix = model.split('.')[0]
+    model_suffix = '.'.join(model.split('.')[-2:])
+    return model_prefix, model_suffix
+
+
+def return_image_cid_qid(image):
+    cid = image.split('_')[4]
+    qid = image.split('_')[6]
+    return cid, qid
+
+
+def return_fringe_model_name(image, fringe_model_folder):
+    model_prefix, model_suffix = return_model_template(fringe_model_folder)
+    cid, qid = return_image_cid_qid(image)
+
+    fringe_model = model_prefix
+    fringe_model += '.%s_%s.' % (cid, qid)
+    fringe_model += model_suffix
+
+    return fringe_model
+
+def download_models(model_date, fringe_model_dir, model_id=None):
+    source_code = requests.get(NERSC_url + model_date)
+    plain_text = source_code.text
+    soup = BeautifulSoup(plain_text, "html.parser")
+
+    outdir = fringe_model_dir + '/' + model_date
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+
+    if model_id:
+        print('Downloading model and model lists %s to %s' % (model_id,
+                                                              outdir))
+    else:
+        print('Downloading all models and model lists to %s' % outdir)
+
+    for link in soup.findAll('a'):
+        href = link.get('href')
+        if 'model' not in href:
+            continue
+        if model_id and model_id not in href:
+            continue
+        wget.download(NERSC_url + model_date + '/' + href, out=outdir)


### PR DESCRIPTION
Ensure that fringez utilities can be called to build modular pipelines while maintaining expected command-line behaviour
- Move utility function from `fringez-download.py`and `fringez-clean.py` to utils.py.
- Break down the `remove_fringe`function. `remove_fringe` now does the correction, `remove_fringe_and_save` handles I/O.

Tested with python ver. 3.12.5. Still working
@MichaelMedford 